### PR TITLE
Remove pr ap

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 require "./app/facade/github_facade"
 
 class ApplicationController < ActionController::Base
-  before_action :user_names, :repo_name, :get_pr
+  before_action :user_names, :repo_name#, :get_pr
 
   def welcome
   end
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
     @repo_name = GitHubFacade.repo_name
   end
 
-  def get_pr
-    @repo_pr_number = GitHubFacade.pull_requests
-  end
+  # def get_pr
+  #   @repo_pr_number = GitHubFacade.pull_requests
+  # end
 end

--- a/app/facade/github_facade.rb
+++ b/app/facade/github_facade.rb
@@ -24,10 +24,10 @@ class GitHubFacade
     user_data.map { |user| user[:login] }
   end
 
-  def self.pull_requests
-    pr_data = GitHubService.get_pull_requests
-    pr_data[0][:number]
-  end
+  # def self.pull_requests
+  #   pr_data = GitHubService.get_pull_requests
+  #   pr_data[0][:number]
+  # end
 
   def self.three_upcoming_holidays
     holiday_data = GitHubService.get_us_holidays

--- a/app/service/github_service.rb
+++ b/app/service/github_service.rb
@@ -12,10 +12,10 @@ class GitHubService
     get_uri_token("https://api.github.com/repos/sjmann2/little-esty-shop/collaborators", headers: {'Authorization' => "Bearer " + ENV["UNAMETOKEN"]})
   end
 
-  def self.get_pull_requests
-    return [{number: 37}] if Rails.env == "test"
-    get_uri("https://api.github.com/repos/sjmann2/little-esty-shop/pulls?state=all")
-  end
+  # def self.get_pull_requests
+  #   return [{number: 37}] if Rails.env == "test"
+  #   get_uri_token("https://api.github.com/repos/sjmann2/little-esty-shop/pulls?state=all", headers: {"Authorization" => "Bearer " + ENV["TOKEN"]})
+  # end
 
   def self.get_us_holidays
     return [{name: 'Columbus Day'}, {name: 'Veterans Day'}, {name: 'Thanksgiving Day'}] if Rails.env == "test"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,6 @@
   <% @user_names.each do |name| %>
     <%= name %> |
     <% end %>  
-   Amount of Pull Requests: <%=@repo_pr_number%></p> 
+   <%# Amount of Pull Requests: <%=@repo_pr_number%>
   </footer>
 </html>

--- a/spec/service/github_service_spec.rb
+++ b/spec/service/github_service_spec.rb
@@ -34,15 +34,15 @@ RSpec.describe(GitHubService) do
   end
   
 
-  it "can get a pull request" do
-    allow(GitHubService).to receive(:get_pull_requests).and_return([{number: 37}])
+  # it "can get a pull request" do
+  #   allow(GitHubService).to receive(:get_pull_requests).and_return([{number: 37}])
 
-    pr_data = GitHubService.get_pull_requests
+  #   pr_data = GitHubService.get_pull_requests
 
-    expect(pr_data).to(be_an(Array))
-    expect(pr_data[0]).to(be_a(Hash))
-    expect(pr_data[0]).to(have_key(:number))
-  end
+  #   expect(pr_data).to(be_an(Array))
+  #   expect(pr_data[0]).to(be_a(Hash))
+  #   expect(pr_data[0]).to(have_key(:number))
+  # end
 
   it 'can get user data' do
     allow(GitHubService).to receive(:get_user_names).and_return([{:login=>"noahvanekdom"}])


### PR DESCRIPTION
This PR comments out the get pull requests api call due to it not having an authorization token and risk of it crashing the app if calls are depleted